### PR TITLE
Move searchbox to top even if no results or error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,6 +34,11 @@ require([
   const resultsBoxEl = document.getElementById("results-box");
 
   search.on("select-result", function (event) {
+    // move searchbox to the top
+    const searchPanel = document.getElementById("search-panel");
+    searchPanel.classList.remove("h-screen");
+    searchPanel.classList.add("mt-10");
+
     database
       .queryFeatures({
         geometry: event.result.feature.geometry,
@@ -49,7 +54,7 @@ require([
           //Add map
           showMap(locationLongitude, locationLatitude);
           //Get info list
-          getList(res, locationLatitude, locationLongitude);
+          getList(res);
         } else {
           resultsBoxEl.innerHTML = "<p>No hay resultados</p>";
         }
@@ -62,13 +67,9 @@ require([
   });
 
   //Get list of results
-  getList = (res, locationLongitude, locationLatitude) => {
+  getList = (res) => {
     console.log("Getting list...");
     res.features.forEach((el) => {
-      const searchPanel = document.getElementById("search-panel");
-      searchPanel.classList.remove("h-screen");
-      searchPanel.classList.add("mt-10");
-
       const listEl = document.createElement("div");
       listEl.className = "md:flex md:gap-8";
       const noLogo = "geosearch.png";


### PR DESCRIPTION
When there are no results or an error the message
was shown at the bottom of the screen and it was
very hard to see. This lead to the user to think that
the app is broken because the message might not be
visible.

Now the searchbox moves to the top in those cases
so the message is visible.